### PR TITLE
Improve performance of search page

### DIFF
--- a/app/models/search/channel.rb
+++ b/app/models/search/channel.rb
@@ -7,7 +7,7 @@ module Search
                 :video_count_from, :video_count_to, :view_count_from, :view_count_to
 
     def search
-      ret = ::Channel.preload(:channel_statistics).preload(:tags)
+      ret = ::Channel.preload(:tags)
       ret = ret.with_channel_statistics
       ret = ret.where(id: ids) if ids.present?
       ret = ret.where("title LIKE ? ESCAPE '\\'", "%#{::Channel.sanitize_sql_like(title)}%") if title.present?

--- a/app/views/channels/_search_result.html.erb
+++ b/app/views/channels/_search_result.html.erb
@@ -26,67 +26,7 @@
 
     <tbody>
     <% channels.each do |c| %>
-      <tr>
-        <td>
-          <% if c.thumbnail_url.present? %>
-            <%= link_to(image_tag(c.thumbnail_url), channel_path(c, take_params)) %>
-          <% end %>
-        </td>
-        <td>
-          <% if c.disabled? %>
-            <span data-toggle="tooltip" title="<%= t('helpers.notice.channel_disabled') %>">⚠️</span>
-          <% end %>
-          <%= print_link(c.title, channel_path(c, take_params), t('text.channel.title.missing')) %>
-          <div>
-            <% c.tags.each do |tag| %>
-              <%= link_to(tag.name, channels_path(search_channel: {tag: tag.name}), class: 'badge rounded-pill bg-secondary', remote: true) %>
-            <% end %>
-          </div>
-        </td>
-        <td class="d-none d-md-table-cell">
-          <%= tag.span print_datetime(c.published_at, format: :date) %>
-        </td>
-        <td>
-          <div class="vertical text-end text-nowrap">
-            <span>
-              <%= print_number(c.subscriber_count) %>
-            </span>
-            <span>
-              <%= print_diff_numbers(c.subscriber_count, c.second_latest_subscriber_count) %>
-            </span>
-          </div>
-        </td>
-        <td class="d-none d-md-table-cell">
-          <div class="vertical text-end text-nowrap">
-            <span>
-              <%= print_number(c.view_count) %>
-            </span>
-            <span>
-              <%= print_diff_numbers(c.view_count, c.second_latest_view_count) %>
-            </span>
-          </div>
-        </td>
-        <td class="d-none d-md-table-cell">
-          <div class="vertical text-end text-nowrap">
-            <span>
-              <%= print_number(c.video_count) %>
-            </span>
-            <span>
-              <%= print_diff_numbers(c.video_count, c.second_latest_video_count) %>
-            </span>
-          </div>
-        </td>
-        <td class="d-none d-xl-table-cell">
-          <div class="vertical text-end text-nowrap">
-            <span>
-              <%= print_acquired_at(c.latest_acquired_at, format: :date) %>
-            </span>
-            <span>
-              <%= print_comparison_period(c.latest_acquired_at, c.second_latest_acquired_at) %>
-            </span>
-          </div>
-        </td>
-      </tr>
+      <%= render partial: 'search_result_row', locals: {channel: c} %>
     <% end %>
     </tbody>
   </table>

--- a/app/views/channels/_search_result_row.html.erb
+++ b/app/views/channels/_search_result_row.html.erb
@@ -11,7 +11,7 @@
     <%= print_link(channel.title, channel_path(channel, take_params), t('text.channel.title.missing')) %>
     <div>
       <% channel.tags.each do |tag| %>
-        <%= link_to(tag.name, channels_path(search_channel: { tag: tag.name }), class: 'badge rounded-pill bg-secondary', remote: true) %>
+        <%= link_to(tag.name, channels_path(search_channel: {tag: tag.name}), class: 'badge rounded-pill bg-secondary', remote: true) %>
       <% end %>
     </div>
   </td>

--- a/app/views/channels/_search_result_row.html.erb
+++ b/app/views/channels/_search_result_row.html.erb
@@ -1,0 +1,61 @@
+<tr>
+  <td>
+    <% if channel.thumbnail_url.present? %>
+      <%= link_to(image_tag(channel.thumbnail_url), channel_path(channel, take_params)) %>
+    <% end %>
+  </td>
+  <td>
+    <% if channel.disabled? %>
+      <span data-toggle="tooltip" title="<%= t('helpers.notice.channel_disabled') %>">⚠️</span>
+    <% end %>
+    <%= print_link(channel.title, channel_path(channel, take_params), t('text.channel.title.missing')) %>
+    <div>
+      <% channel.tags.each do |tag| %>
+        <%= link_to(tag.name, channels_path(search_channel: { tag: tag.name }), class: 'badge rounded-pill bg-secondary', remote: true) %>
+      <% end %>
+    </div>
+  </td>
+  <td class="d-none d-md-table-cell">
+    <%= tag.span print_datetime(channel.published_at, format: :date) %>
+  </td>
+  <td>
+    <div class="vertical text-end text-nowrap">
+      <span>
+        <%= print_number(channel.subscriber_count) %>
+      </span>
+      <span>
+        <%= print_diff_numbers(channel.subscriber_count, channel.second_latest_subscriber_count) %>
+      </span>
+    </div>
+  </td>
+  <td class="d-none d-md-table-cell">
+    <div class="vertical text-end text-nowrap">
+      <span>
+        <%= print_number(channel.view_count) %>
+      </span>
+      <span>
+        <%= print_diff_numbers(channel.view_count, channel.second_latest_view_count) %>
+      </span>
+    </div>
+  </td>
+  <td class="d-none d-md-table-cell">
+    <div class="vertical text-end text-nowrap">
+      <span>
+        <%= print_number(channel.video_count) %>
+      </span>
+      <span>
+        <%= print_diff_numbers(channel.video_count, channel.second_latest_video_count) %>
+      </span>
+    </div>
+  </td>
+  <td class="d-none d-xl-table-cell">
+    <div class="vertical text-end text-nowrap">
+      <span>
+        <%= print_acquired_at(channel.latest_acquired_at, format: :date) %>
+      </span>
+      <span>
+        <%= print_comparison_period(channel.latest_acquired_at, channel.second_latest_acquired_at) %>
+      </span>
+    </div>
+  </td>
+</tr>

--- a/test/fixtures/channels.yml
+++ b/test/fixtures/channels.yml
@@ -36,3 +36,9 @@ disabled_channel:
   published_at: '2022-06-19T01:23:34'
   disabled: true
 
+no_statistics_channel:
+  channel_id: channel_id5
+  title: 'Channel4'
+  description: no statistics records
+  thumbnail_url: https://example.com/thumbnail/4
+  published_at: '2023-11-12T01:23:34'

--- a/test/models/search/channel_test.rb
+++ b/test/models/search/channel_test.rb
@@ -14,7 +14,7 @@ module Search
     test 'search by id' do
       channel = Search::Channel.new(ids: [@c1.id])
       ret = channel.search
-      assert_includes ret, @c1
+      assert_equal ret, [@c1]
     end
 
     test 'search by title' do


### PR DESCRIPTION
Rendering of search results is taking a long time. The log shows that the value of Allocations is very large.
```
Completed 200 OK in 1262ms (Views: 1230.7ms | ActiveRecord: 15.0ms | Allocations: 1467587)
```

Change the search logic to improve performance.

Log after improvement:
```
Completed 200 OK in 221ms (Views: 157.2ms | ActiveRecord: 54.9ms | Allocations: 171880)
```

Details are below:
- Stop preloading channel_statistics since it does not need to read all of them.
- This has nothing to do with performance improvement: Fix the search to include channel records with no channel_statistics.

Reference:
- [Rails(ActiveRecord)で自在にSQLを書く手段いろいろ](https://takakisan.com/rails-sql/)
- [【SQL】グループごとに最大の値を持つレコードを取得する方法3選](https://takakisan.com/sql-max-in-each-group/)