### PR TITLE
Enable lazy loading on channel statistics

### DIFF
--- a/app/controllers/channels/statistics_controller.rb
+++ b/app/controllers/channels/statistics_controller.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Channels
+  class StatisticsController < ApplicationController
+    before_action :set_channel
+
+    def index
+      return redirect_to channel_path(@channel) unless turbo_frame_request?
+
+      channel_statistics = @channel.channel_statistics.paginate(page: params[:page], per: params[:per])
+      render partial: 'channels/statistics_frame', locals: {channel_statistics: channel_statistics}
+    end
+
+    private
+
+    def set_channel
+      @channel = Channel.find(params[:channel_id])
+    end
+  end
+end

--- a/app/controllers/channels_controller.rb
+++ b/app/controllers/channels_controller.rb
@@ -23,7 +23,6 @@ class ChannelsController < ApplicationController
   end
 
   def show
-    @channel_statistics = @channel.channel_statistics.paginate(per: params[:statics_per], page: params[:statics_page])
     respond_to do |format|
       format.html
     end

--- a/app/views/channels/_snippets.html.erb
+++ b/app/views/channels/_snippets.html.erb
@@ -34,4 +34,5 @@
   <% else %>
     <%= t('text.channel.snippets.missing') %>
   <% end %>
+  <%= render partial: 'partials/loader' %>
 <% end %>

--- a/app/views/channels/_snippets_frame.html.erb
+++ b/app/views/channels/_snippets_frame.html.erb
@@ -2,5 +2,4 @@
   <div id="search-snippets">
     <%= render partial: 'channels/snippets', locals: {channel_snippets: channel_snippets} %>
   </div>
-  <%= render partial: 'partials/loader' %>
 <% end %>

--- a/app/views/channels/_statistics.html.erb
+++ b/app/views/channels/_statistics.html.erb
@@ -25,7 +25,7 @@
       <% end %>
       </tbody>
     </table>
-    <%= paginate channel_statistics, remote: true, param_name: 'statics_page' %>
+    <%= paginate channel_statistics, remote: true %>
   <% else %>
     <%= t('text.channel.statistics.missing') %>
   <% end %>

--- a/app/views/channels/_statistics_frame.html.erb
+++ b/app/views/channels/_statistics_frame.html.erb
@@ -1,0 +1,5 @@
+<%= turbo_frame_tag 'statistics-frame' do %>
+  <div id="search-statistics">
+    <%= render partial: 'channels/statistics', locals: {channel_statistics: channel_statistics} %>
+  </div>
+<% end %>

--- a/app/views/channels/show.html.erb
+++ b/app/views/channels/show.html.erb
@@ -75,6 +75,7 @@
   <%= render partial: 'partials/loader' %>
 <% end %>
 
-<div id="search-statistics">
-  <%= render 'statistics', channel_statistics: @channel_statistics %>
-</div>
+<%= turbo_frame_tag 'statistics-frame', src: channel_statistics_path(channel_id: @channel.id), loading: :lazy do %>
+  <div id="search-statistics"></div>
+  <%= render partial: 'partials/loader' %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,6 +32,7 @@ Rails.application.routes.draw do
       end
       scope module: :channels do
         resources :snippets, only: [:index]
+        resources :statistics, only: [:index]
       end
     end
 

--- a/test/controllers/channels/statistics_controller_test.rb
+++ b/test/controllers/channels/statistics_controller_test.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Channels
+  class StatisticsControllerTest < ActionDispatch::IntegrationTest
+    setup do
+      @channel = channels(:channel1)
+    end
+
+    test 'should get index' do
+      get channel_statistics_path(channel_id: @channel.id), headers: {'Turbo-Frame' => 'foo'}
+      assert_response :success
+    end
+
+    test 'should redirect to channel_path if not turbo frame' do
+      get channel_statistics_path(channel_id: @channel.id)
+      assert_response :redirect
+      assert_redirected_to channel_path(@channel)
+    end
+  end
+end


### PR DESCRIPTION
Enable lazy-loading on channel statistics page as well as #1619.
The spinner display was also fixed.